### PR TITLE
:hammer: REF[#6] 퀴즈,추천 질문LLM은 원본기사 1개당 1번 호출되도록 수정

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,149 +1,58 @@
 from fastapi import FastAPI, HTTPException
 import asyncio
 from schemas import (
-    RewriteRequest, RewriteResponse, TokensUsed,
-    RewriteBatchRequest, RewriteBatchResponse, RewriteBatchItemResult, RewriteBatchItemIn, ChatArticleRequest, ChatArticleResponse,
-    RewriteBatchMultiResponse, RewriteBatchItemMultiResult,RewriteVariant, RewriteMultiResponse
+    RewriteRequest,TokensUsed,
+    RewriteBatchRequest,ChatArticleRequest, ChatArticleResponse,
+    RewriteBatchMultiResponse, RewriteBatchItemMultiResult,
+    RewriteVariant, RewriteMultiResponse
 )
-from llm_client import call_llm, suggest_questions_and_quiz, chat_about_article, evaluate_epi, run_one_style
+from llm_client import suggest_questions_and_quiz, chat_about_article, build_variants_for_styles
 
 app = FastAPI(title="Article Rewriter API", version="1.3.1")
 
 CONCURRENCY_ARTICLES = 4 #한번에 요청 개수 제한
 
-@app.post("/v1/rewrite-summarize", response_model=RewriteResponse)
-async def rewrite_summarize(payload: RewriteRequest):
-    body = payload.body.strip()
-    if len(body) < 50:
-        raise HTTPException(status_code=422, detail="본문이 너무 짧습니다(최소 50자).")
-    try:
-        new_title, summary, in1, out1, model, lat1 = call_llm(payload.title, body)
-        questions, quiz, in2, out2, _, lat2 = suggest_questions_and_quiz(payload.title, body)
-        epi_json, in3, out3, _, lat3, reason = evaluate_epi(payload.title, body, new_title, summary)
-
-        epi = {
-            "epiOriginal": int(epi_json["original"]["EPI"]),
-            "epiSummary": int(epi_json["summary"]["EPI"]),
-            "reductionPct": float(epi_json.get("reductionPct", 0)),
-            "stimulationReduced": str(epi_json.get("stimulationReduced", "자극도를 0% 줄였어요")),
-            "componentsOriginal": {k: float(epi_json["original"][k]) for k in
-                                   ("S","SUBJ","K","F","C","V","X","EVID")},
-            "componentsSummary":  {k: float(epi_json["summary"][k])  for k in
-                                   ("S","SUBJ","K","F","C","V","X","EVID")},
-            "reason": reason
-        }
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-
-    return RewriteResponse(
-        articleId=payload.articleId,
-        newTitle=new_title.strip(),
-        summary=summary.strip(),
-        questions=questions,
-        quiz=quiz,
-        tokensUsed=TokensUsed(input=in1 + in2 + in3, output=out1 + out2 + out3),
-        model=model,
-        latencyMs=lat1 + lat2 + lat3,
-        epi=epi
-    )
-
 @app.post("/v1/rewrite-summarize3", response_model=RewriteMultiResponse)
 async def rewrite_summarize3(payload: RewriteRequest):
     body = payload.body.strip()
     if len(body) < 50:
-        # FastAPI의 HTTPException 대신, 명확한 422 메시지 유지
         raise HTTPException(status_code=422, detail="본문이 너무 짧습니다(최소 50자).")
 
     styles = ["CONCISE", "FRIENDLY", "NEUTRAL"]
 
-    async def run(style):
-        return await asyncio.to_thread(run_one_style, style, payload.title, body)
-
-    # 3개 스타일 병렬 실행
-    results = await asyncio.gather(*(run(s) for s in styles))
-
-    # totals
-    total_in = sum(r["tokensUsed"]["input"] for r in results)
-    total_out = sum(r["tokensUsed"]["output"] for r in results)
-    total_latency = sum(r["latencyMs"] for r in results)
-
-    variants = []
-    for r in results:
-        variants.append(RewriteVariant(
-            newsStyle=r["newsStyle"],
-            articleId=payload.articleId,
-            newTitle=r["newTitle"],
-            summary=r["summary"],
-            questions=r["questions"],
-            quiz=r["quiz"],
-            tokensUsed=TokensUsed(**r["tokensUsed"]),
-            model=r["model"],
-            latencyMs=r["latencyMs"],
-            epi=r["epi"]
-        ))
-
-    return RewriteMultiResponse(
-        articleId=payload.articleId,
-        variants=variants,
-        tokensUsedTotal=TokensUsed(input=total_in, output=total_out),
-        latencyMsTotal=total_latency
+    # [변경] 스타일별 요약/EPI 한번에 생성 (질문/퀴즈는 여기서 만들지 않음)
+    variants, v_in, v_out, v_lat = await asyncio.to_thread(
+        build_variants_for_styles, payload.title, body, styles
     )
 
-@app.post("/v1/rewrite-batch", response_model=RewriteBatchResponse)
-async def rewrite_batch(payload: RewriteBatchRequest):
-    sem = asyncio.Semaphore(CONCURRENCY_ARTICLES)
+    # [추가] 기사당 1회만 질문/퀴즈 생성
+    questions, quiz, q_in, q_out, _, q_lat = await asyncio.to_thread(
+        suggest_questions_and_quiz, payload.title, body
+    )
 
-    async def process_one(item: RewriteBatchItemIn) -> RewriteBatchItemResult:
-        async with sem:
-            body = (item.body or "").strip()
-            if len(body) < 50:
-                return RewriteBatchItemResult(
-                    articleId=item.articleId, ok=False,
-                    error="본문이 너무 짧습니다(최소 50자)."
-                )
-            try:
-                new_title, summary, in1, out1, model, lat1 = await asyncio.to_thread(
-                    call_llm, item.title, body
-                )
-                questions, quiz, in2, out2, _, lat2 = await asyncio.to_thread(
-                    suggest_questions_and_quiz, item.title, body
-                )
-                epi_json, in3, out3, _, lat3, reason = await asyncio.to_thread(
-                    evaluate_epi, item.title, body, new_title, summary
-                )
-
-                epi = {
-                    "epiOriginal": int(epi_json["original"]["EPI"]),
-                    "epiSummary": int(epi_json["summary"]["EPI"]),
-                    "reductionPct": float(epi_json.get("reductionPct", 0)),
-                    "stimulationReduced": str(epi_json.get("stimulationReduced", "자극도를 0% 줄였어요")),
-                    "componentsOriginal": {k: float(epi_json["original"][k]) for k in
-                                           ("S", "SUBJ", "K", "F", "C", "V", "X", "EVID")},
-                    "componentsSummary": {k: float(epi_json["summary"][k]) for k in
-                                          ("S", "SUBJ", "K", "F", "C", "V", "X", "EVID")},
-                    "reason": reason
-                }
-
-                resp = RewriteResponse(
-                    articleId=item.articleId,
-                    newTitle=new_title.strip(),
-                    summary=summary.strip(),
-                    questions=questions,
-                    quiz=quiz,
-                    tokensUsed=TokensUsed(input=in1 + in2 + in3, output=out1 + out2 + out3),
-                    model=model,
-                    latencyMs=lat1 + lat2 + lat3,
-                    epi=epi
-                )
-                return RewriteBatchItemResult(articleId=item.articleId, ok=True, data=resp)
-            except Exception as e:
-                return RewriteBatchItemResult(articleId=item.articleId, ok=False, error=str(e))
-
-    tasks = [process_one(it) for it in payload.items]
-    results = await asyncio.gather(*tasks)
-    return RewriteBatchResponse(results=list(results))
-
-CONCURRENCY_ARTICLES = 4
+    # [변경] per-variant tokens 제거 → 최상위 합계만
+    return RewriteMultiResponse(
+        articleId=payload.articleId,
+        variants=[
+            RewriteVariant(
+                newsStyle=v["newsStyle"],
+                articleId=payload.articleId,
+                newTitle=v["newTitle"],
+                summary=v["summary"],
+                # [삭제] variants 내부 questions/quiz 삭제
+                # [삭제] tokensUsed 삭제
+                model=v["model"],
+                latencyMs=v["latencyMs"],
+                epi=v["epi"]
+            )
+            for v in variants
+        ],
+        # [추가] 공통 질문/퀴즈를 최상위에 포함시켜야 하므로 스키마에 반영 필요(아래 schemas.py 참고)
+        questions=questions,
+        quiz=quiz,
+        tokensUsedTotal=TokensUsed(input=v_in + q_in, output=v_out + q_out),
+        latencyMsTotal=v_lat + q_lat
+    )
 
 @app.post("/v1/rewrite-batch3", response_model=RewriteBatchMultiResponse)
 async def rewrite_batch3(payload: RewriteBatchRequest):
@@ -160,34 +69,35 @@ async def rewrite_batch3(payload: RewriteBatchRequest):
             try:
                 styles = ["CONCISE", "FRIENDLY", "NEUTRAL"]
 
-                async def run(style):
-                    return await asyncio.to_thread(run_one_style, style, item.title, body)
-
-                results = await asyncio.gather(*(run(s) for s in styles))
-                total_in = sum(r["tokensUsed"]["input"] for r in results)
-                total_out = sum(r["tokensUsed"]["output"] for r in results)
-                total_latency = sum(r["latencyMs"] for r in results)
-
-                variants = []
-                for r in results:
-                    variants.append(RewriteVariant(
-                        newsStyle=r["newsStyle"],
-                        articleId=item.articleId,
-                        newTitle=r["newTitle"],
-                        summary=r["summary"],
-                        questions=r["questions"],
-                        quiz=r["quiz"],
-                        tokensUsed=TokensUsed(**r["tokensUsed"]),
-                        model=r["model"],
-                        latencyMs=r["latencyMs"],
-                        epi=r["epi"]
-                    ))
+                # [변경] 스타일별 요약/EPI 일괄 생성
+                variants, v_in, v_out, v_lat = await asyncio.to_thread(
+                    build_variants_for_styles, item.title, body, styles
+                )
+                # [추가] 기사당 1회만 질문/퀴즈 생성
+                questions, quiz, q_in, q_out, _, q_lat = await asyncio.to_thread(
+                    suggest_questions_and_quiz, item.title, body
+                )
 
                 data = RewriteMultiResponse(
                     articleId=item.articleId,
-                    variants=variants,
-                    tokensUsedTotal=TokensUsed(input=total_in, output=total_out),
-                    latencyMsTotal=total_latency
+                    variants=[
+                        RewriteVariant(
+                            newsStyle=v["newsStyle"],
+                            articleId=item.articleId,
+                            newTitle=v["newTitle"],
+                            summary=v["summary"],
+                            # [삭제] variants 내부 questions/quiz/tokensUsed 제거
+                            model=v["model"],
+                            latencyMs=v["latencyMs"],
+                            epi=v["epi"]
+                        )
+                        for v in variants
+                    ],
+                    # [추가] 공통 질문/퀴즈: 최상위에 배치
+                    questions=questions,
+                    quiz=quiz,
+                    tokensUsedTotal=TokensUsed(input=v_in + q_in, output=v_out + q_out),
+                    latencyMsTotal=v_lat + q_lat
                 )
                 return RewriteBatchItemMultiResult(articleId=item.articleId, ok=True, data=data)
             except Exception as e:

--- a/schemas.py
+++ b/schemas.py
@@ -29,18 +29,6 @@ class EpiResult(BaseModel):
     componentsSummary: Dict[str, float]
     reason: str
 
-# ------- 뉴스 요약 응답 -----
-class RewriteResponse(BaseModel):
-    articleId: str
-    newTitle: str
-    summary: str
-    questions: List[str]
-    quiz: Quiz
-    tokensUsed: TokensUsed
-    model: str
-    latencyMs: int
-    epi: EpiResult
-
 # ------- 배치 전용(느슨하게: body 길이 제한 없음) -------
 class RewriteBatchItemIn(BaseModel):
     articleId: StrMin1
@@ -49,15 +37,6 @@ class RewriteBatchItemIn(BaseModel):
 
 class RewriteBatchRequest(BaseModel):
     items: List[RewriteBatchItemIn]
-
-class RewriteBatchItemResult(BaseModel):
-    articleId: str
-    ok: bool
-    data: Optional[RewriteResponse] = None
-    error: Optional[str] = None
-
-class RewriteBatchResponse(BaseModel):
-    results: List[RewriteBatchItemResult]
 
 # ------- 챗 봇 -------
 
@@ -80,14 +59,13 @@ class ChatArticleResponse(BaseModel):
     model: str
     latencyMs: int
 
+# ------- 스타일별 변형 스키마 -------
+
 class RewriteVariant(BaseModel):
     newsStyle: NewsStyle
     articleId: str
     newTitle: str
     summary: str
-    questions: List[str]
-    quiz: Quiz
-    tokensUsed: TokensUsed
     model: str
     latencyMs: int
     epi: EpiResult
@@ -95,10 +73,12 @@ class RewriteVariant(BaseModel):
 class RewriteMultiResponse(BaseModel):
     articleId: str
     variants: List[RewriteVariant]          # 길이 3 (스타일별)
+    questions: List[str]                    # 질문/퀴즈는 기사당 1세트
+    quiz: Quiz
     tokensUsedTotal: TokensUsed             # variants 합계
     latencyMsTotal: int                     # variants 합계(또는 max)
 
-# 배치용 결과도 멀티 버전을 추가
+# 배치용 결과도 멀티 버전을 사용
 class RewriteBatchItemMultiResult(BaseModel):
     articleId: str
     ok: bool


### PR DESCRIPTION
## 🔍 이슈 번호
[#6]
## ✨ PR 요약
<!--변경 포인트-->
- 퀴즈,추천 질문LLM은 원본기사 1개당 1번 호출되도록 수정
---
## 🛠 상세 설명
<!-- 변경 포인트 상세 설명-->
- 기존에 요약기사 버전3개에서 각각 퀴즈/추천 질문 LLM을 호출 하던 로직을
- 원본 기사 1개방 1번 호출되도록 변경하고 이에 맞게 res를 수정

---
